### PR TITLE
pcclAllReduceMultipleWithRetry: remove non cache friendly container

### DIFF
--- a/src/pccl.cpp
+++ b/src/pccl.cpp
@@ -3,7 +3,7 @@
 #include <optional>
 #include <ccoip_master.hpp>
 #include <pccl_log.hpp>
-#include <unordered_set>
+#include <vector>
 
 static constinit bool pccl_initialized = false;
 
@@ -389,7 +389,7 @@ pcclResult_t pcclAllReduceMultipleWithRetry(const pcclReduceOpDescriptor_t *desc
 
     // stores all indices of completed reduce operations
     // in range [0, count)
-    std::unordered_set<size_t> completed_ops{};
+    std::vector<bool> completed_ops(count, false);
 
     while (local_world_size > 1) {
         bool all_done = true;
@@ -398,7 +398,7 @@ pcclResult_t pcclAllReduceMultipleWithRetry(const pcclReduceOpDescriptor_t *desc
             if (reduce_handle_opt == std::nullopt) {
                 // no reduce handle exists for this operation yet,
                 // so it needs to be launched.
-                if (completed_ops.contains(i)) {
+                if (completed_ops[i]) {
                     continue;
                 }
                 // the reduce handle is not yet completed
@@ -428,7 +428,7 @@ pcclResult_t pcclAllReduceMultipleWithRetry(const pcclReduceOpDescriptor_t *desc
             // check if all operations have been launched
             bool all_launched = true;
             for (size_t j = 0; j < count; ++j) {
-                if (reduce_handles[j] == std::nullopt && !completed_ops.contains(j)) {
+                if (reduce_handles[j] == std::nullopt && !completed_ops[j]) {
                     all_launched = false;
                     break;
                 }
@@ -463,7 +463,7 @@ pcclResult_t pcclAllReduceMultipleWithRetry(const pcclReduceOpDescriptor_t *desc
                     if (h_j != std::nullopt) {
                         const pcclResult_t s_j = pcclAwaitAsyncReduce(&h_j.value(), nullptr);
                         if (s_j == pcclSuccess) {
-                            completed_ops.insert(j);
+                            completed_ops[j] = true;
                         }
                         in_flight--;
                     }
@@ -477,7 +477,7 @@ pcclResult_t pcclAllReduceMultipleWithRetry(const pcclReduceOpDescriptor_t *desc
             }
             // success for this handle
             reduce_handles[i] = std::nullopt;
-            completed_ops.insert(i);
+            completed_ops[i] = true;
 
             total_tx += reduce_info.tx_bytes;
             total_rx += reduce_info.rx_bytes;


### PR DESCRIPTION
Small change to extract more perf.

- std::unordered_set<T> has a few shortcomings here:
  - Storing of (0, count] is susceptible to resizing, causing our hot path to stall due to heap (re)allocations
  - The pattern access of (0, count] is cache friendly and we don't leverage this since std::unordered_set is non contiguous
  - Larger memory overhead than std::vector

If this loop involves network calls, then `std::unordered_set` will not be the bottleneck. That said, notice that reduce_handles was explicitly resized to prevent any heap reallocations during execution. While it’s possible to also `reserve()` space in the set, it isn't a cache friendly container for contiguous access. That and the straightforward nature of our use case here make a std::vector look good.
