### PR TITLE
Integrate new piquant

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,6 +17,7 @@
 [submodule "third_party/piquant"]
 	path = third_party/piquant
 	url = https://github.com/PrimeIntellect-ai/piquant.git
+	branch = main
 
 [submodule "third_party/threadpool"]
 	path = third_party/threadpool

--- a/ccoip/internal/piquant_utils.hpp
+++ b/ccoip/internal/piquant_utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <thread>
 
 #include <piquant.hpp>
@@ -10,31 +11,13 @@ namespace ccoip::internal {
         return s_ctx;
     }
 
-    [[nodiscard]] inline piquant::dtype get_piquant_dtype(const ccoip_data_type_t type) {
+    [[nodiscard]] inline std::optional<piquant::dtype> get_piquant_dtype(const ccoip_data_type_t type) {
         switch (type) {
-            case ccoipInt8:
-                return piquant::dtype::int8;
-            case ccoipUint8:
-                return piquant::dtype::uint8;
-            case ccoipInt16:
-                return piquant::dtype::int16;
-            case ccoipUint16:
-                return piquant::dtype::uint16;
-            case ccoipInt32:
-                return piquant::dtype::int32;
-            case ccoipUint32:
-                return piquant::dtype::uint32;
-            case ccoipInt64:
-                return piquant::dtype::int64;
-            case ccoipUint64:
-                return piquant::dtype::uint64;
-            case ccoipFloat:
-                return piquant::dtype::f32;
-            case ccoipDouble:
-                return piquant::dtype::f64;
-            default:
-                break;
+            case ccoipFloat: return piquant::dtype::f32;
+            case ccoipBFloat16: return piquant::dtype::bf16;
+            case ccoipUint8: return piquant::dtype::uint8;
+            // Todo: add support for sub-byte types like uint4, uint2 etc
+            default: return std::nullopt;
         }
-        throw std::logic_error{"Unsupported data type"};
     }
 }

--- a/ccoip/src/cpp/quantize.cpp
+++ b/ccoip/src/cpp/quantize.cpp
@@ -11,6 +11,12 @@ ccoip::internal::quantize::DeQuantizationMetaData ccoip::internal::quantize::per
     const std::span<std::byte> &dst_span, const std::span<const std::byte> &src_span,
     const ccoip_quantization_algorithm_t quantization_algorithm,
     const ccoip_data_type_t quantized_type, const ccoip_data_type_t data_type) {
+    std::optional<piquant::dtype> quant_type = get_piquant_dtype(quantized_type);
+    std::optional<piquant::dtype> dequant_type = get_piquant_dtype(data_type);
+    if (!quant_type.has_value() || !dequant_type.has_value()) {
+        LOG(BUG) << "Unsupported quantized type: " << quantized_type;
+        return {};
+    }
     switch (quantization_algorithm) {
         case ccoipQuantizationNone: {
             LOG(BUG) << "performQuantization should never be called with ccoipQuantizationNone.";
@@ -21,21 +27,27 @@ ccoip::internal::quantize::DeQuantizationMetaData ccoip::internal::quantize::per
         }
         case ccoipQuantizationZeroPointScale: {
             std::pair<float, std::int64_t> quant_params{};
+            std::optional<piquant::dtype> quant_type = get_piquant_dtype(quantized_type);
+            std::optional<piquant::dtype> dequant_type = get_piquant_dtype(data_type);
+            if (!quant_type.has_value() || !dequant_type.has_value()) {
+                LOG(BUG) << "Unsupported quantized type: " << quantized_type;
+                return {};
+            }
             switch (data_type) {
                 case ccoipFloat:
                     quant_params = get_quant_ctx().compute_quant_config_from_data(
                         std::span{
-                            reinterpret_cast<const float *>(src_span.data()), src_span.size_bytes() / sizeof(float)
+                            reinterpret_cast<const piquant::fp32_t*>(src_span.data()), src_span.size_bytes() / sizeof(piquant::fp32_t)
                         },
-                        get_piquant_dtype(quantized_type)
+                        *quant_type
                     );
                     break;
-                case ccoipDouble:
+                case ccoipBFloat16:
                     quant_params = get_quant_ctx().compute_quant_config_from_data(
                         std::span{
-                            reinterpret_cast<const double *>(src_span.data()), src_span.size_bytes() / sizeof(double)
+                            reinterpret_cast<const piquant::bfp16_t*>(src_span.data()), src_span.size_bytes() / sizeof(piquant::bfp16_t)
                         },
-                        get_piquant_dtype(quantized_type)
+                        *quant_type
                     );
                     break;
                 default: {
@@ -46,9 +58,9 @@ ccoip::internal::quantize::DeQuantizationMetaData ccoip::internal::quantize::per
             auto [scale, zp] = quant_params;
             get_quant_ctx().quantize(
                 src_span,
-                get_piquant_dtype(data_type),
+                *dequant_type,
                 dst_span,
-                get_piquant_dtype(quantized_type),
+                *quant_type,
                 scale,
                 zp,
                 piquant::round_mode::nearest
@@ -79,21 +91,27 @@ void ccoip::internal::quantize::performQuantizationAndDequantization(const std::
         }
         case ccoipQuantizationZeroPointScale: {
             std::pair<float, std::int64_t> quant_params{};
+            std::optional<piquant::dtype> quant_type = get_piquant_dtype(quantized_type);
+            std::optional<piquant::dtype> dequant_type = get_piquant_dtype(data_type);
+            if (!quant_type.has_value() || !dequant_type.has_value()) {
+                LOG(BUG) << "Unsupported quantized type: " << quantized_type;
+                return;
+            }
             switch (data_type) {
                 case ccoipFloat:
                     quant_params = get_quant_ctx().compute_quant_config_from_data(
                         std::span{
-                            reinterpret_cast<const float *>(src_span.data()), src_span.size_bytes() / sizeof(float)
+                            reinterpret_cast<const piquant::fp32_t*>(src_span.data()), src_span.size_bytes() / sizeof(piquant::fp32_t)
                         },
-                        get_piquant_dtype(quantized_type)
+                        *quant_type
                     );
                     break;
-                case ccoipDouble:
+                case ccoipBFloat16:
                     quant_params = get_quant_ctx().compute_quant_config_from_data(
                         std::span{
-                            reinterpret_cast<const double *>(src_span.data()), src_span.size_bytes() / sizeof(double)
+                            reinterpret_cast<const piquant::bfp16_t*>(src_span.data()), src_span.size_bytes() / sizeof(piquant::bfp16_t)
                         },
-                        get_piquant_dtype(quantized_type)
+                        *quant_type
                     );
                     break;
                 default: {
@@ -103,9 +121,9 @@ void ccoip::internal::quantize::performQuantizationAndDequantization(const std::
             auto [scale, zp] = quant_params;
             get_quant_ctx().quantize_dequantize_fused(
                 src_span,
-                get_piquant_dtype(data_type),
+                *dequant_type,
                 dst_span,
-                get_piquant_dtype(quantized_type),
+                *quant_type,
                 scale,
                 zp,
                 piquant::round_mode::nearest,

--- a/ccoip/src/cpp/reduce_kernels.cpp
+++ b/ccoip/src/cpp/reduce_kernels.cpp
@@ -368,14 +368,16 @@ void performReduction(const std::span<std::byte> &dst,
     switch (op) {
         case ccoip::ccoipOpSet:
             if (quantization_algorithm == ccoip::ccoipQuantizationZeroPointScale) {
-                if (src_type != dst_type) {
+                std::optional<piquant::dtype> pq_src = ccoip::internal::get_piquant_dtype(src_type);
+                std::optional<piquant::dtype> pq_dst = ccoip::internal::get_piquant_dtype(dst_type);
+                if (src_type != dst_type && pq_src.has_value() && pq_dst.has_value()) {
                     const auto scale = meta_data.scaleAs<float>();
                     const auto zp = meta_data.zeroPointAs<std::int64_t>();
                     ccoip::internal::get_quant_ctx().dequantize(
                         src,
-                        ccoip::internal::get_piquant_dtype(src_type),
+                        *pq_src,
                         dst,
-                        ccoip::internal::get_piquant_dtype(dst_type),
+                        *pq_dst,
                         scale,
                         zp,
                         piquant::reduce_op::set);
@@ -391,14 +393,16 @@ void performReduction(const std::span<std::byte> &dst,
         case ccoip::ccoipOpSum:
         case ccoip::ccoipOpAvg:
             if (quantization_algorithm == ccoip::ccoipQuantizationZeroPointScale) {
-                if (src_type != dst_type) {
+                std::optional<piquant::dtype> pq_src = ccoip::internal::get_piquant_dtype(src_type);
+                std::optional<piquant::dtype> pq_dst = ccoip::internal::get_piquant_dtype(dst_type);
+                if (src_type != dst_type && pq_src.has_value() && pq_dst.has_value()) {
                     const auto scale = meta_data.scaleAs<float>();
                     const auto zp = meta_data.zeroPointAs<std::int64_t>();
                     ccoip::internal::get_quant_ctx().dequantize(
                         src,
-                        ccoip::internal::get_piquant_dtype(src_type),
+                        *pq_src,
                         dst,
-                        ccoip::internal::get_piquant_dtype(dst_type),
+                        *pq_dst,
                         scale,
                         zp,
                         piquant::reduce_op::add);

--- a/ccoip/tests/end_to_end/test_all_reduce.cpp
+++ b/ccoip/tests/end_to_end/test_all_reduce.cpp
@@ -45,14 +45,14 @@ template<typename T>
 class TypeAllReduceTest : public testing::Test {
 };
 
-typedef testing::Types<uint8_t, int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float, double> AllReduceTestTypes;
+typedef testing::Types<uint8_t, int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float> AllReduceTestTypes;
 TYPED_TEST_SUITE(TypeAllReduceTest, AllReduceTestTypes);
 
 template<typename T>
 class QuantizeTypedAllReduceTest : public testing::Test {
 };
 
-typedef testing::Types<float, double> AllReduceQuantizeTestTypes;
+typedef testing::Types<float> AllReduceQuantizeTestTypes;
 TYPED_TEST_SUITE(QuantizeTypedAllReduceTest, AllReduceQuantizeTestTypes);
 
 inline ccoip::ccoip_data_type_t getCcoipDataType(const std::type_info &ti) {


### PR DESCRIPTION
This integrates the latest piquant version with support for bf16.
The new piquant version also removed support for strange datatype combinations,
such has float64 to int64 quantization. PCCL not errors out on combinations like these.